### PR TITLE
Changed ReleaseYear to ReleaseDate for databinding include parameter

### DIFF
--- a/WorldwideMovieDatabase/Controllers/MoviesController.cs
+++ b/WorldwideMovieDatabase/Controllers/MoviesController.cs
@@ -46,7 +46,7 @@ namespace WorldwideMovieDatabase.Controllers
         // more details see https://go.microsoft.com/fwlink/?LinkId=317598.
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public ActionResult Create([Bind(Include = "ID,Title,ReleaseYear,UserRating,MPAARating,MovieLength,Genre,Description")] Movie movie)
+        public ActionResult Create([Bind(Include = "ID,Title,ReleaseDate,UserRating,MPAARating,MovieLength,Genre,Description")] Movie movie)
         {
             if (ModelState.IsValid)
             {


### PR DESCRIPTION
The error was happening since I changed the name of the property ReleaseYear to ReleaseDate. The string parameter ([Bind(Include = "ID,Title,ReleaseYear...") was not updated so the minimum DateTime (01/01/1000) was applied by default (since it was non-nullable) instead of the entered value. Since the C# DateTime minimum is less than the SQL date time minimum (01/01/1753) this threw the DateTime out of range exception.